### PR TITLE
esbuild: [ERROR] The JSX syntax extension is not currently enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Babel config can be either passed to `babelConfig` field or via Babel config fil
 By default, babel is run for JS/JSX files. You can change that vie `filter` option.
 
 | Name | Type | Default | Description |
-| -- | -- | -- | -- |
-| `babelConfig` | `object` | `{}` | [Babel Options](https://babeljs.io/docs/en/options) |
-| `filter` | `RegExp` | `/\.jsx?$/` | wich files is babel applied to. By default it's js/jsx files |
-| `apply` | `serve | build` | `undefined` | limit plugin usage to only build or only serve. If not specified, will be run during both cycles |
+|---|---|---|---|
+| `apply` | `serve` or `build` | `undefined` | Limits plugin usage to only build or only serve. If not specified, will be run during both cycles. |
+| `babelConfig` | `object` | `{}` | [Babel Transform Options](https://babeljs.io/docs/en/options) |
+| `filter` | `RegExp` | `/\.jsx?$/` | Which files is babel applied to. By default, it's js/jsx files. |
+| `loader` | `Loader` or `(path: string) => Loader` | `undefined` | This tells esbuild how to interpret the contents after babel's transformation. For example, the js loader interprets the contents as JavaScript and the css loader interprets the contents as CSS. The loader defaults to js if it's not specified. See the [Content Types](https://esbuild.github.io/content-types) page for a complete list of all built-in loaders. |
 
 ## Tips
-
 Vite team didn't enabled and included Babel by default, because they wanted to keep expirience as fast as possible and esbuild can already do a lot of things, you would probably do with Babel. Because of that, we recommend to only include those Babel plugins you really need. You can use option `babelConfig.plugin` and disable usage of Babel config file, ex.:
 
 ```js
@@ -64,6 +64,31 @@ babel({
 or just use `.babelrc.json`.
 
 __NOTE:__ Any babel plugins and presets need to be installed seperately and are not included with this package.
+
+## Troubleshooting
+
+#### [ERROR] The JSX syntax extension is not currently enabled
+This usually happens when you're using this plugin to only transform part of a `.jsx` file (such as decorators), and leaving the JSX syntax untouched. By default, esbuild interprets contents as `.js`, so you'll need to specify the loader esbuild should use.
+
+Example:
+```js
+import { extname } from 'path';
+// ...
+babel({
+    babelConfig: {
+        babelrc: false,
+        configFile: false,
+        plugin: ['@babel/plugin-proposal-decorators'],
+        
+        // uses the jsx loader for .jsx files
+        loader: path => {
+          if (extname(path) === '.jsx') {
+            return 'jsx';
+          }
+        },
+    }
+})
+```
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,19 @@
 import babel, { TransformOptions } from '@babel/core';
+import { Loader } from 'esbuild';
 import { Plugin } from 'vite';
 
 import { esbuildPluginBabel } from './esbuildBabel';
 
 export interface BabelPluginOptions {
-    filter?: RegExp;
-    babelConfig?: TransformOptions;
-	apply?: 'serve' | 'build';
+  apply?: 'serve' | 'build';
+  babelConfig?: TransformOptions;
+  filter?: RegExp;
+  loader?: Loader | ((path: string) => Loader);
 }
 
 const DEFAULT_FILTER = /\.jsx?$/;
 
-const babelPlugin = ({ babelConfig = {}, filter = DEFAULT_FILTER, apply }: BabelPluginOptions = {}): Plugin => {
+const babelPlugin = ({ babelConfig = {}, filter = DEFAULT_FILTER, apply, loader }: BabelPluginOptions = {}): Plugin => {
 	return {
 		name: 'babel-plugin',
 
@@ -24,8 +26,9 @@ const babelPlugin = ({ babelConfig = {}, filter = DEFAULT_FILTER, apply }: Babel
 					esbuildOptions: {
 						plugins: [
 							esbuildPluginBabel({
-								filter,
 								config: { ...babelConfig },
+								filter,
+                loader,
 							}),
 						],
 					},
@@ -33,7 +36,7 @@ const babelPlugin = ({ babelConfig = {}, filter = DEFAULT_FILTER, apply }: Babel
 			};
 		},
 
-		transform(code, id) {
+    transform(code, id) {
 			const shouldTransform = filter.test(id);
 
 			if (!shouldTransform) return;


### PR DESCRIPTION
This problem happens when you're using this plugin to only transform part of a `.jsx` file (such as decorators), and leaving the JSX syntax untouched. By default, esbuild interprets contents as `js`, so you'll need to specify the loader esbuild should use.

This solves the problem by allowing a loader to be specified in the config (or a function that received the file path and returns the loader). That way the user can instruct esbuild on how to interpret the file that their babel config will generate.

I haven't specified the default loader as `jsx` because loading all `.js` files as `.jsx` may not be optimal. Not defining it also maintains the current behavior of not specifying a loader.

Example:
```js
import { extname } from 'path';
// ...
babel({
    babelConfig: {
        babelrc: false,
        configFile: false,
        plugin: ['@babel/plugin-proposal-decorators'],
        
        // uses the jsx loader for .jsx files
        loader: path => {
          if (extname(path) === '.jsx') {
            return 'jsx';
          }
        },
    }
})
```