### PR TITLE
feat: allow filter to have JavaScript specific regex features in development

### DIFF
--- a/esbuildBabel.ts
+++ b/esbuildBabel.ts
@@ -57,7 +57,11 @@ export const esbuildPluginBabel = (options: ESBuildPluginBabelOptions = {}): Plu
 			});
 		};
 
-		build.onLoad({ filter, namespace }, async args => {
+		build.onLoad({ filter: /.*/, namespace }, async args => {
+			const shouldTransform = filter.test(args.path);
+
+			if (!shouldTransform) return;
+
 			const contents = await fs.promises.readFile(args.path, 'utf8');
 
 			return transformContents(args, contents);


### PR DESCRIPTION
Same as #17 but with proper indentation

Fix https://github.com/owlsdepartment/vite-plugin-babel/issues/12

This PR makes filter in development (esbuild) behaves the same when building (rollup)

It tests the JavaScript filter directly instead of passing to esbuild.

Esbuild uses Go Regex which is pretty limited compared to JS engine: https://github.com/evanw/esbuild/issues/1634#issuecomment-927204088