### PR TITLE
Separate type outputs for cjs/esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,25 @@
   "name": "vite-plugin-babel",
   "version": "1.3.1",
   "description": "Runs Babel in Vite during all commands",
+  "type": "commonjs",
   "main": "dist/index.cjs",
-  "types": "dist/index.d.ts",
   "module": "dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./*": "./dist/*"
   },
   "files": [
-    "/dist"
+    "package.json",
+    "dist"
   ],
   "scripts": {
     "clean": "rm -rf dist",
@@ -52,5 +58,11 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+  },
+  "prettier": {
+    "printWidth": 100,
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 2
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,37 +1,69 @@
-import esbuild from 'rollup-plugin-esbuild'
-import dts from 'rollup-plugin-dts'
+import esbuild from 'rollup-plugin-esbuild';
+import dts from 'rollup-plugin-dts';
 import { defineConfig } from 'rollup';
 
-type FormatType = 'dts' | 'cjs' | 'esm';
-const EXTENTIONS: Record<FormatType, string> = {
-	cjs: 'cjs',
-	dts: 'd.ts',
-	esm: 'mjs'
-}
+const input = 'index.ts';
+const external = (id: string) => !/^[./]/.test(id);
 
-const bundle = (format: FormatType) => {
-	const ext = EXTENTIONS[format];
-	const file = `dist/index.${ext}`;
+export default defineConfig([
+  {
+    input,
+    output: [
+      {
+        file: `dist/index.cjs`,
+        sourcemap: false,
+        format: 'cjs',
+        exports: 'named',
+      },
+    ],
 
-	return defineConfig({
-		input: 'index.ts',
+    plugins: [esbuild({ target: 'es2020' })],
 
-		output: {
-			file,
+    external,
+  },
+  {
+    input,
+    output: [
+      {
+        file: `dist/index.d.cts`,
+        sourcemap: false,
+        format: 'cjs',
+        exports: 'named',
+      },
+    ],
 
-			sourcemap: false,
-			format: format === 'cjs' ? 'cjs' : 'esm',
-			exports: 'named'
-		},
+    plugins: [dts()],
 
-		plugins: format == 'dts' ? [dts()] : [esbuild({ target: 'es2020' })],
+    external,
+  },
+  {
+    input,
+    output: [
+      {
+        file: `dist/index.mjs`,
+        sourcemap: false,
+        format: 'esm',
+        exports: 'named',
+      },
+    ],
 
-		external: id => !/^[./]/.test(id),
-	})
-}
+    plugins: [esbuild({ target: 'es2020' })],
 
-export default [
-	bundle('cjs'),
-	bundle('esm'),
-	bundle('dts'),
-]
+    external,
+  },
+  {
+    input,
+    output: [
+      {
+        file: `dist/index.d.mts`,
+        sourcemap: false,
+        format: 'esm',
+        exports: 'named',
+      },
+    ],
+
+    plugins: [dts()],
+
+    external,
+  },
+]);


### PR DESCRIPTION
I noticed a type issue using the default export while consuming this plugin from an ESM context. This PR resolves the type issue I encountered by building and exporting separate type files for CJS and ESM versions.

[Publint](https://publint.dev/) confirmed the issue. See here: https://publint.dev/vite-plugin-babel@1.3.1


From the [Publint docs](https://publint.dev/rules#exports_types_invalid_format):

> Since TypeScript 5.0, it has emphasized that type files (*.d.ts) are also affected by its ESM and CJS context, and both contexts affect how the exported types is interpreted. This means that you can't share a single type file for both ESM and CJS exports of your library. You need to have two type files (albeit largely similar contents) when dual-publishing your library.