### PR TITLE
Add option to run on optimizeDeps for SSR also

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export interface BabelPluginOptions {
 	include?: FilterPattern
 	exclude?: FilterPattern
 	loader?: Loader | ((path: string) => Loader);
+	transformSsr?: boolean;
 }
 
 const DEFAULT_FILTER = /\.jsx?$/;
@@ -26,7 +27,20 @@ const babelPlugin = ({
 	enforce = 'pre',
 	loader
 }: BabelPluginOptions = {}): Plugin => {
-	const customFilter = createFilter(include, exclude)
+	const customFilter = createFilter(include, exclude);
+
+	const optimizeDeps = {
+		esbuildOptions: {
+			plugins: [
+				esbuildPluginBabel({
+					config: { ...babelConfig },
+					customFilter,
+					filter,
+					loader,
+				}),
+			],
+		},
+	};
 
 	return {
 		name: 'babel-plugin',
@@ -36,18 +50,8 @@ const babelPlugin = ({
 
 		config() {
 			return {
-				optimizeDeps: {
-					esbuildOptions: {
-						plugins: [
-							esbuildPluginBabel({
-								config: { ...babelConfig },
-								customFilter,
-								filter,
-								loader,
-							}),
-						],
-					},
-				},
+				optimizeDeps,
+				ssr: transformSsr ? { optimizeDeps } : undefined,
 			};
 		},
 


### PR DESCRIPTION
Add `transformSsr` to also run on optimizeDeps for SSR deps. This makes
the plugin work better with f.ex. `@cloudflare/vite-plugin`, which
handles SSR environment deps separate from client deps.


I don't know exactly what the best way to handle this is, but this is a suggestion for how to do this at least.