### PR TITLE
fix: support Vite 8 by using rolldownOptions for dep optimization

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,9 @@
 import babel, { PartialConfig, TransformOptions } from '@babel/core';
 import { Loader } from 'esbuild';
-import { createFilter, FilterPattern, Plugin } from 'vite';
+import { createFilter, FilterPattern, Plugin, version as viteVersion } from 'vite';
 
 import { esbuildPluginBabel } from './esbuildBabel';
+import { rolldownPluginBabel } from './rolldownBabel';
 import { Filter, testFilter } from './filter'
 
 export interface BabelPluginOptions {
@@ -29,18 +30,39 @@ const babelPlugin = ({
 	optimizeOnSSR = false,
 }: BabelPluginOptions = {}): Plugin => {
 	const customFilter = createFilter(include, exclude);
-	const getOptimizeDeps = () => ({
-		esbuildOptions: {
-			plugins: [
-				esbuildPluginBabel({
-					config: { ...babelConfig },
-					customFilter,
-					filter,
-					loader,
-				}),
-			],
-		},
-	})
+	const viteMajor = parseInt(viteVersion.split('.')[0], 10);
+
+	const getOptimizeDeps = () => {
+		// Vite 8+ replaced esbuild with Rolldown for dependency pre-bundling.
+		// Use rolldownOptions with a Rolldown-compatible plugin; fall back to
+		// the legacy esbuildOptions for older Vite versions.
+		if (viteMajor >= 8) {
+			return {
+				rolldownOptions: {
+					plugins: [
+						rolldownPluginBabel({
+							config: { ...babelConfig },
+							customFilter,
+							filter,
+						}),
+					],
+				},
+			};
+		}
+
+		return {
+			esbuildOptions: {
+				plugins: [
+					esbuildPluginBabel({
+						config: { ...babelConfig },
+						customFilter,
+						filter,
+						loader,
+					}),
+				],
+			},
+		};
+	}
 
 	let root: string | undefined;
 	let babelPartialConfig: PartialConfig | null;
@@ -86,4 +108,5 @@ const babelPlugin = ({
 
 export default babelPlugin;
 export * from './esbuildBabel';
+export * from './rolldownBabel';
 export type { Filter }

--- a/rolldownBabel.ts
+++ b/rolldownBabel.ts
@@ -1,0 +1,42 @@
+import babel, { TransformOptions } from '@babel/core';
+import { Filter, testFilter } from './filter';
+
+/**
+ * A Rolldown-compatible plugin that applies Babel transforms.
+ * Used for `optimizeDeps.rolldownOptions.plugins` in Vite 8+,
+ * where esbuild was replaced by Rolldown for dependency pre-bundling.
+ */
+export interface RolldownPluginBabelOptions {
+	config?: TransformOptions;
+	filter?: Filter;
+	customFilter: (id: unknown) => boolean;
+}
+
+export const rolldownPluginBabel = ({
+	config = {},
+	filter = /.*/,
+	customFilter,
+}: RolldownPluginBabelOptions) => ({
+	name: 'babel',
+
+	async transform(code: string, id: string) {
+		const shouldTransform = customFilter(id) && testFilter(filter, id);
+
+		if (!shouldTransform) return null;
+
+		const babelOptions = babel.loadOptions({
+			filename: id,
+			...config,
+			caller: {
+				name: 'rolldown-plugin-babel',
+				supportsStaticESM: true,
+			},
+		}) as TransformOptions;
+
+		if (!babelOptions) return null;
+
+		const result = await babel.transformAsync(code, babelOptions);
+
+		return result ? { code: result.code ?? '', map: result.map } : null;
+	},
+});


### PR DESCRIPTION
Vite 8 replaced esbuild with Rolldown for dependency pre-bundling, deprecating `optimizeDeps.esbuildOptions` in favour of `optimizeDeps.rolldownOptions`. This caused a deprecation warning when using vite-plugin-babel with Vite 8.

- Add `rolldownBabel.ts` with a Rolldown-compatible transform plugin
- Detect the Vite major version at runtime and use `rolldownOptions` (with the new Rolldown plugin) for Vite 8+, falling back to the existing `esbuildOptions` path for Vite 2–7
- Export `rolldownPluginBabel` for consumers who need direct access

Closes #35