### PR TITLE
chore: upgrade Babel to 8.0.0-rc.3 and update related dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "vite-plugin-babel",
       "devDependencies": {
-        "@babel/core": "^7.23.6",
+        "@babel/core": "8.0.0-rc.3",
         "@rollup/plugin-typescript": "^11.1.5",
         "@types/babel__core": "^7.20.5",
         "@types/node": "^20.10.4",
@@ -17,43 +17,39 @@
         "vite": "^8.0.0",
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0",
+        "@babel/core": "^7.0.0 || ^8.0.0-0",
         "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
       },
     },
   },
   "packages": {
-    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+    "@babel/code-frame": ["@babel/code-frame@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0-rc.3", "js-tokens": "^10.0.0" } }, "sha512-585nwYQGQKKc+jMIAPeZJ+aGMn4FHmIUUjLZa9zI7mslvYmShnx0u7rFA4gliRip6S2vkwTYrMxPeXadkKW93Q=="],
 
-    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+    "@babel/compat-data": ["@babel/compat-data@8.0.0-rc.3", "", {}, "sha512-TlS7d9xYz/93xC8ovkRBwTKPodbwPfzTn7TxUgZo4c3LwpPINnScqIlN0QRDE/x1S4C1bmyqxGmAZUIC0buW0A=="],
 
-    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+    "@babel/core": ["@babel/core@8.0.0-rc.3", "", { "dependencies": { "@babel/code-frame": "^8.0.0-rc.3", "@babel/generator": "^8.0.0-rc.3", "@babel/helper-compilation-targets": "^8.0.0-rc.3", "@babel/helpers": "^8.0.0-rc.3", "@babel/parser": "^8.0.0-rc.3", "@babel/template": "^8.0.0-rc.3", "@babel/traverse": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "@jridgewell/remapping": "^2.3.5", "@types/gensync": "^1.0.0", "convert-source-map": "^2.0.0", "gensync": "^1.0.0-beta.2", "import-meta-resolve": "^4.2.0", "json5": "^2.2.3", "obug": "^2.1.1", "semver": "^7.7.3" }, "peerDependencies": { "@babel/preset-typescript": "^8.0.0-0" }, "optionalPeers": ["@babel/preset-typescript"] }, "sha512-ov5mBbHiosqX1eqt8nN0JM7VuhirO6V8lln5rUXNZpNB+a9NnPTVYeDqSTBkf9C6GmFq3fnFlGT8eg3QBI7jJQ=="],
 
-    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+    "@babel/generator": ["@babel/generator@8.0.0-rc.3", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA=="],
 
-    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@8.0.0-rc.3", "", { "dependencies": { "@babel/compat-data": "^8.0.0-rc.3", "@babel/helper-validator-option": "^8.0.0-rc.3", "browserslist": "^4.24.0", "lru-cache": "^7.14.1", "semver": "^7.7.3" } }, "sha512-UXlT7t103KBJjiphN7Ij9DtELX2Q5uk1xMle7oN/eckxR8dmJyvbFsIm5u+cY0KZyF7qNkAiLsJljEPix1yfKg=="],
 
-    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+    "@babel/helper-globals": ["@babel/helper-globals@8.0.0-rc.3", "", {}, "sha512-rwtdZPunoa/IAlcZhgDoLxROXPW5evSN7SXMdObS8vNt7Wu6fCf8nLPFcuuhLCzeRoIrGNKx08v/XEQ4riQDGg=="],
 
-    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
 
-    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@8.0.0-rc.3", "", {}, "sha512-wpzZ9KycQDqmJct4ee/ihua2KKdW/MXTDidD4Ya7HdUHL+Jp5zBZTj8oNrxc8wp5Qr4sofKgZF1GIyymfdq7+g=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helpers": ["@babel/helpers@8.0.0-rc.3", "", { "dependencies": { "@babel/template": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3" } }, "sha512-dbPuulmsPOwIAXP4pGsKiAv1E50pKYmAJfWXYytCwLpgj6IDNUFAzGuVVemaphYP/WniKsCf42+Cfo4xpc4jjQ=="],
 
-    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+    "@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
-    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+    "@babel/template": ["@babel/template@8.0.0-rc.3", "", { "dependencies": { "@babel/code-frame": "^8.0.0-rc.3", "@babel/parser": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3" } }, "sha512-9iet2svxZhCGgmt/b6M3Fbmy2i+OgjhXMDWNqDTBrNvb9Cc60NgETNIaJq6b0wICiCqpsFdIt8NYXMXyCQU6jA=="],
 
-    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+    "@babel/traverse": ["@babel/traverse@8.0.0-rc.3", "", { "dependencies": { "@babel/code-frame": "^8.0.0-rc.3", "@babel/generator": "^8.0.0-rc.3", "@babel/helper-globals": "^8.0.0-rc.3", "@babel/parser": "^8.0.0-rc.3", "@babel/template": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "obug": "^2.1.1" } }, "sha512-3gvZCynaX+zxYZ2v5odaBBcc9eT4Yr7Gf16l3QSEvvBPVyMSZbYhsGAZfO79kjOCNJY2j6rWvNkWl1ZwYa64lQ=="],
 
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
-
-    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
-
-    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 
@@ -225,6 +221,10 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/gensync": ["@types/gensync@1.0.4", "", {}, "sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA=="],
+
+    "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
+
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ=="],
@@ -261,9 +261,11 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -293,7 +295,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -302,6 +304,8 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -325,7 +329,7 @@
 
     "rollup-plugin-esbuild": ["rollup-plugin-esbuild@6.2.1", "", { "dependencies": { "debug": "^4.4.0", "es-module-lexer": "^1.6.0", "get-tsconfig": "^4.10.0", "unplugin-utils": "^0.2.4" }, "peerDependencies": { "esbuild": ">=0.18.0", "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -345,6 +349,38 @@
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "@types/babel__core/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@types/babel__core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__generator/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__template/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@types/babel__template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@types/babel__traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "rollup-plugin-dts/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@types/babel__core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@types/babel__generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@types/babel__generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@types/babel__template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@types/babel__template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@types/babel__traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "rollup-plugin-dts/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "rollup-plugin-dts/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
   }
 }

--- a/esbuildBabel.ts
+++ b/esbuildBabel.ts
@@ -1,68 +1,83 @@
-import babel, { TransformOptions } from '@babel/core';
-import { Loader, Plugin, OnLoadArgs, OnLoadResult } from 'esbuild';
-import fs from 'fs';
-import path from 'path';
-import { Filter, testFilter } from './filter';
+import {
+  InputOptions,
+  loadPartialConfigSync,
+  transformAsync,
+} from "@babel/core";
+import { Loader, Plugin, OnLoadArgs, OnLoadResult } from "esbuild";
+import fs from "fs";
+import path from "path";
+import { Filter, testFilter } from "./filter";
 
 /**
  * Original: https://github.com/nativew/esbuild-plugin-babel
  * Copied and customized, because there was a problem with `type: "module"` in `package.json`
  */
 export interface ESBuildPluginBabelOptions {
-	config?: TransformOptions;
-	filter?: Filter;
-	customFilter: (id: unknown) => boolean
-	namespace?: string;
-	loader?: Loader | ((path: string) => Loader);
+  config?: InputOptions;
+  filter?: Filter;
+  customFilter: (id: unknown) => boolean;
+  namespace?: string;
+  loader?: Loader | ((path: string) => Loader);
 }
 
-export const esbuildPluginBabel = (options: ESBuildPluginBabelOptions): Plugin => ({
-	name: 'babel',
+export const esbuildPluginBabel = (
+  options: ESBuildPluginBabelOptions,
+): Plugin => ({
+  name: "babel",
 
-	setup(build) {
-		const { filter = /.*/, namespace = '', config = {}, loader, customFilter } = options;
+  setup(build) {
+    const {
+      filter = /.*/,
+      namespace = "",
+      config = {},
+      loader,
+      customFilter,
+    } = options;
 
-		const resolveLoader = (args: OnLoadArgs): Loader | undefined => {
-			if (typeof loader === 'function') {
-				return loader(args.path);
-			}
-			return loader;
-		};
+    const resolveLoader = (args: OnLoadArgs): Loader | undefined => {
+      if (typeof loader === "function") {
+        return loader(args.path);
+      }
+      return loader;
+    };
 
-		const transformContents = async (args: OnLoadArgs, contents: string): Promise<OnLoadResult> => {
-			const babelOptions = babel.loadOptions({
-				filename: args.path,
-				...config,
-				caller: {
-					name: 'esbuild-plugin-babel',
-					supportsStaticESM: true,
-				},
-			}) as TransformOptions;
+    const transformContents = async (
+      args: OnLoadArgs,
+      contents: string,
+    ): Promise<OnLoadResult> => {
+      const babelConfig = loadPartialConfigSync({
+        filename: args.path,
+        ...config,
+        caller: {
+          name: "esbuild-plugin-babel",
+          supportsStaticESM: true,
+        },
+      });
+      const babelOptions = babelConfig?.options;
 
-			if (!babelOptions) {
-				return { contents, loader: resolveLoader(args) };
-			}
+      if (!babelOptions) {
+        return { contents, loader: resolveLoader(args) };
+      }
 
-			if (babelOptions.sourceMaps) {
-				babelOptions.sourceFileName = path.relative(process.cwd(), args.path);
-			}
+      if (babelOptions.sourceMaps) {
+        babelOptions.sourceFileName = path.relative(process.cwd(), args.path);
+      }
 
-			return babel
-				.transformAsync(contents, babelOptions)
-				.then((result) => ({
-					contents: result?.code ?? '',
-					loader: resolveLoader(args),
-				}));
-			};
+      return transformAsync(contents, babelOptions).then((result) => ({
+        contents: result?.code ?? "",
+        loader: resolveLoader(args),
+      }));
+    };
 
-		build.onLoad({ filter: /.*/, namespace }, async args => {
-			const shouldTransform = customFilter(args.path) && testFilter(filter, args.path);
+    build.onLoad({ filter: /.*/, namespace }, async (args) => {
+      const shouldTransform =
+        customFilter(args.path) && testFilter(filter, args.path);
 
-			if (!shouldTransform) return;
+      if (!shouldTransform) return;
 
-			const contents = await fs.promises.readFile(args.path, 'utf8');
+      const contents = await fs.promises.readFile(args.path, "utf8");
 
-			return transformContents(args, contents);
-		});
-	},
+      return transformContents(args, contents);
+    });
+  },
 });

--- a/index.ts
+++ b/index.ts
@@ -1,89 +1,115 @@
-import babel, { PartialConfig, TransformOptions } from '@babel/core';
-import { Loader } from 'esbuild';
-import { createFilter, FilterPattern, Plugin } from 'vite';
+import {
+  InputOptions,
+  PartialConfig,
+  loadPartialConfigSync,
+  transformAsync,
+} from "@babel/core";
+import { Loader } from "esbuild";
+import { SourceMapInput } from "rollup";
+import { createFilter, FilterPattern, Plugin } from "vite";
 
-import { esbuildPluginBabel } from './esbuildBabel';
-import { Filter, testFilter } from './filter'
+import { esbuildPluginBabel } from "./esbuildBabel";
+import { Filter, testFilter } from "./filter";
 
 export interface BabelPluginOptions {
-	apply?: Plugin['apply'];
-	enforce?: Plugin['enforce'];
-	babelConfig?: TransformOptions;
-	filter?: Filter;
-	include?: FilterPattern
-	exclude?: FilterPattern
-	loader?: Loader | ((path: string) => Loader);
-	optimizeOnSSR?: boolean;
+  apply?: Plugin["apply"];
+  enforce?: Plugin["enforce"];
+  babelConfig?: InputOptions;
+  filter?: Filter;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+  loader?: Loader | ((path: string) => Loader);
+  optimizeOnSSR?: boolean;
 }
 
 const DEFAULT_FILTER = /\.jsx?$/;
 
 const babelPlugin = ({
-	babelConfig = {},
-	filter = DEFAULT_FILTER,
-	include,
-	exclude,
-	apply,
-	enforce = 'pre',
-	loader,
-	optimizeOnSSR = false,
+  babelConfig = {},
+  filter = DEFAULT_FILTER,
+  include,
+  exclude,
+  apply,
+  enforce = "pre",
+  loader,
+  optimizeOnSSR = false,
 }: BabelPluginOptions = {}): Plugin => {
-	const customFilter = createFilter(include, exclude);
-	const getOptimizeDeps = () => ({
-		esbuildOptions: {
-			plugins: [
-				esbuildPluginBabel({
-					config: { ...babelConfig },
-					customFilter,
-					filter,
-					loader,
-				}),
-			],
-		},
-	})
+  const customFilter = createFilter(include, exclude);
+  const getOptimizeDeps = () => ({
+    esbuildOptions: {
+      plugins: [
+        esbuildPluginBabel({
+          config: { ...babelConfig },
+          customFilter,
+          filter,
+          loader,
+        }),
+      ],
+    },
+  });
 
-	let root: string | undefined;
-	let babelPartialConfig: PartialConfig | null;
+  let root: string | undefined;
+  let babelPartialConfig: PartialConfig | null;
 
-	const getBabelOptions = () => {
-		if (babelPartialConfig) return babelPartialConfig.options;
+  const getBabelOptions = () => {
+    if (babelPartialConfig) return babelPartialConfig.options;
 
-		babelPartialConfig = babel.loadPartialConfig({ cwd: root, root, ...babelConfig });
+    babelPartialConfig = loadPartialConfigSync({
+      cwd: root,
+      root,
+      ...babelConfig,
+    });
 
-		return babelPartialConfig?.options ?? {};
-	};
+    return babelPartialConfig?.options ?? {};
+  };
 
-	return {
-		name: 'babel-plugin',
+  return {
+    name: "babel-plugin",
 
-		apply,
-		enforce,
+    apply,
+    enforce,
 
-		config() {
-			return {
-				optimizeDeps: getOptimizeDeps(),
-				ssr: optimizeOnSSR ? { optimizeDeps: getOptimizeDeps() } : undefined,
-			};
-		},
+    config() {
+      return {
+        optimizeDeps: getOptimizeDeps(),
+        ssr: optimizeOnSSR ? { optimizeDeps: getOptimizeDeps() } : undefined,
+      };
+    },
 
-		configResolved(config) {
-			root = config.root;
-		},
+    configResolved(config) {
+      root = config.root;
+    },
 
-		transform(code, id) {
-			const shouldTransform = customFilter(id) && testFilter(filter, id);
+    transform(code, id) {
+      const shouldTransform = customFilter(id) && testFilter(filter, id);
 
-			if (!shouldTransform) return;
+      if (!shouldTransform) return;
 
-			const babelOptions = getBabelOptions();
+      const babelOptions = getBabelOptions();
 
-			return babel
-				.transformAsync(code, {  ...babelOptions, filename: id })
-				.then((result) => ({ code: result?.code ?? '', map: result?.map }));
-		},
-	};
+      return transformAsync(code, { ...babelOptions, filename: id }).then(
+        (result) => {
+          const map: SourceMapInput | undefined = result?.map
+            ? {
+                version: result.map.version,
+                file: result.map.file ?? undefined,
+                sourceRoot: result.map.sourceRoot,
+                sources: result.map.sources.map((source) => source ?? ""),
+                sourcesContent: result.map.sourcesContent
+                  ? result.map.sourcesContent.map((content) => content ?? "")
+                  : undefined,
+                names: [...result.map.names],
+                mappings: result.map.mappings,
+              }
+            : undefined;
+
+          return { code: result?.code ?? "", map };
+        },
+      );
+    },
+  };
 };
 
 export default babelPlugin;
-export * from './esbuildBabel';
-export type { Filter }
+export * from "./esbuildBabel";
+export type { Filter };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel"
   ],
   "devDependencies": {
-    "@babel/core": "^7.23.6",
+    "@babel/core": "8.0.0-rc.3",
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^20.10.4",
@@ -55,7 +55,7 @@
     "vite": "^8.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^8.0.0-0",
     "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
- Updated @babel/core to version 8.0.0-rc.3 in package.json and bun.lock.
- Adjusted peer dependencies to support Babel 8.0.0-0.
- Refactored esbuildBabel.ts to use loadPartialConfigSync and transformAsync from @babel/core.
- Enhanced babelPlugin in index.ts to accommodate new Babel API and improved source map handling.
- Updated dependencies in bun.lock to align with Babel 8.0.0-rc.3 requirements.