### PR TITLE
fix: return babel options from getBabelOptions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -115,6 +115,8 @@ function useBabelConfig(babelConfig: TransformOptions) {
 				...babelConfig.caller,
 			},
 		});
+
+		return babelPartialConfig?.options ?? {};
 	}
 
 	return {


### PR DESCRIPTION
1.7.0's `useBabelConfig` refactor accidentally dropped the trailing `return` from `getBabelOptions`. First call returns undefined, so `transform` spreads undefined into the babel options and Babel runs with no presets/plugins on the first transformed module.

For react-compiler users that means auto-memoization never runs and the page re-renders itself to death — same symptom as #39.

Fix is just restoring the line that was there in 1.6.0:

```diff
   babelPartialConfig = babel.loadPartialConfig({ ... });
+
+  return babelPartialConfig?.options ?? {};
 }
```

Closes #39.
