### PR TITLE
fix: warn when `filter` is used without `include`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,18 @@ export default defineConfig({
 
 Babel config can be either passed to `babelConfig` field or via Babel config file. For all babel options see: [Babel Options](https://babeljs.io/docs/en/options).
 
-By default, babel is run for JS/JSX files. You can change that vie `filter` option.
+By default, babel is run for JS/JSX files (`include` defaults to `/\.jsx?$/`). To scope it to other files, set `include` / `exclude` and add the matching Babel presets/plugins to `babelConfig` yourself.
+
+> **Migrating from 1.6.x:** in 1.7.0 the default of `include` changed from `undefined` to `/\.jsx?$/`. If you previously relied on `filter` alone to scope files, set `include` explicitly to your desired scope — `filter` is now combined with `include` as an AND, so it can only narrow further, not expand. `filter` is deprecated; prefer `include` / `exclude`.
 
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `apply` | `'serve' \| 'build' \| (config: UserConfig, env: ConfigEnv) => boolean` | `undefined` | Limits plugin usage to only build or only serve. If not specified, will be run during both cycles. Same as [`apply` in Vite Plugins API](https://vite.dev/guide/api-plugin.html#conditional-application) |
 | `enforce` | `'pre' \| 'post'` | `pre` | Force plugin's order execution. More details: [Vite Plugin Ordering](https://vite.dev/guide/api-plugin.html#plugin-ordering) |
 | `babelConfig` | `object` | `{}` | [Babel Transform Options](https://babeljs.io/docs/en/options) |
-| `filter` | `RegExp \| (id: string) => boolean` | `/\.jsx?$/` | Which files is babel applied to. By default, it's js/jsx files. You can pass a filter function that accepts file name and returns `true \| false` |
-| `include` | `string \| RegExp \| Array<string\|RegExp>)` | `undefined` | which files to include. If omitted, all are included |
-| `exclude` | `string \| RegExp \| Array<string\|RegExp>)` | `undefined` | which files to exclude. If used with `include`, it will have higher priority and can exclude files, that match `include` pattern |
+| `include` | `string \| RegExp \| Array<string\|RegExp>` | `/\.jsx?$/` | Which files to include. Defaults to `.js` / `.jsx`. Set explicitly to scope to other extensions — the matching Babel presets/plugins are your responsibility. |
+| `exclude` | `string \| RegExp \| Array<string\|RegExp>` | `undefined` | Which files to exclude. Takes priority over `include`. |
+| `filter` | `RegExp \| (id: string) => boolean` | `undefined` | **Deprecated.** Combined with `include` as an AND — can only narrow further, not expand. Prefer `include` / `exclude`. |
 | `loader` | `Loader` or `(path: string) => Loader` | `undefined` | **Vite 7 and lower** This tells esbuild how to interpret the contents after babel's transformation. For example, the js loader interprets the contents as JavaScript and the css loader interprets the contents as CSS. The loader defaults to js if it's not specified. See the [Content Types](https://esbuild.github.io/content-types) page for a complete list of all built-in loaders. |
 | `optimizeOnSSR` | `boolean` | `false` | Run dependency optimization during SSR. Could be useful when running a project on a cloud workers, like `@cloudflare/vite-plugin` |
 

--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,13 @@ export interface BabelPluginOptions {
 	enforce?: Plugin['enforce'];
 	babelConfig?: TransformOptions;
 	/**
-	 * @deprecated planned for deprecation in favour of include/exclude as they should be faster
-	 * and this would only accepts functions
+	 * @deprecated Use `include` / `exclude` instead.
+	 *
+	 * `filter` is combined with `include` as an AND, and since 1.7.0 `include`
+	 * defaults to `/\.jsx?$/`. Files outside that default are filtered out
+	 * before `filter` runs, so passing only `filter` cannot expand the file
+	 * scope. Set `include` explicitly to match your filter, or migrate to
+	 * `include` / `exclude` entirely.
 	 */
 	filter?: Filter;
 	include?: FilterPattern
@@ -37,6 +42,19 @@ const babelPlugin = ({
 	optimizeOnSSR = false,
 }: BabelPluginOptions = {}): Plugin => {
 	const isVite8OrHigher = viteMajorVersion >= 8;
+
+	// Help users migrating from 1.6.x: `filter` is now AND-ed with `include`,
+	// which defaults to `/\.jsx?$/`. If they relied on `filter` alone to scope
+	// to other extensions, those files are silently skipped — surface the
+	// migration path instead of leaving Babel transforms unapplied.
+	if (filter !== undefined && include === undefined) {
+		console.warn(
+			'[vite-plugin-babel] `filter` is applied after `include` (default since 1.7.0: `/\\.jsx?$/`). ' +
+			'Files outside that default are skipped. ' +
+			'Set `include` explicitly to match your filter, or migrate to `include` / `exclude` entirely.'
+		);
+	}
+
 	const customFilter = createFilter(include, exclude);
 	const transformFilter = (id: string) => customFilter(id) && testFilter(filter, id);
 


### PR DESCRIPTION
1.7.0 flipped the default of `include` from `undefined` to `/\.jsx?$/` and deprecated `filter`. Since `filter` is AND-ed with `include` inside `transformFilter`, anyone on 1.6.x who scoped files via `filter` alone now silently loses any file outside `.js`/`.jsx` after bumping — no error, no warning, transforms just don't run.

This PR doesn't change behavior, only surfaces it:

- Emit a one-shot `console.warn` at plugin init when `filter` is set and `include` isn't, pointing at the migration.
- Tighten the JSDoc on `filter` to spell out the AND interaction with `include`.
- Update the README config table (it still listed `filter` defaulting to `/\.jsx?$/` and `include` defaulting to `undefined`, both reversed in 1.7.x) and drop in a migration note for 1.6.x users.

No default changes — keeping `include = /\.jsx?$/` as the default is correct, since the matching Babel presets/plugins for other extensions are on the user.
